### PR TITLE
Add an explicit "Geometry Ceiling Height" parameter,

### DIFF
--- a/project_national/housing_characteristics/Geometry Ceiling Height.tsv
+++ b/project_national/housing_characteristics/Geometry Ceiling Height.tsv
@@ -1,0 +1,3 @@
+Option=8 ft	Option=9 ft	Option=10 ft	sampling_probability
+1	0	0	1
+# Source: T110-nrgx add: move geometry_average_ceiling_height from Gemetry Building Type RECS (always 8 ft) to a separate "Geometry Ceiling Height"

--- a/resources/options_lookup.tsv
+++ b/resources/options_lookup.tsv
@@ -40,11 +40,14 @@ Geometry Attic Type	None	ResStockArguments	geometry_attic_type=FlatRoof	geometry
 Geometry Attic Type	Vented Attic	ResStockArguments	geometry_attic_type=VentedAttic	geometry_roof_type=gable	geometry_roof_pitch=6:12																						
 Geometry Attic Type	Unvented Attic	ResStockArguments	geometry_attic_type=UnventedAttic	geometry_roof_type=gable	geometry_roof_pitch=6:12																						
 Geometry Attic Type	Finished Attic or Cathedral Ceilings	ResStockArguments	geometry_attic_type=ConditionedAttic	geometry_roof_type=gable	geometry_roof_pitch=6:12																						
-Geometry Building Type RECS	Single-Family Detached	ResStockArguments	geometry_unit_type=single-family detached	geometry_average_ceiling_height=8	geometry_unit_aspect_ratio=1.8																						
-Geometry Building Type RECS	Single-Family Attached	ResStockArguments	geometry_unit_type=single-family attached	geometry_average_ceiling_height=8	geometry_unit_aspect_ratio=0.5556																						
-Geometry Building Type RECS	Multi-Family with 2 - 4 Units	ResStockArguments	geometry_unit_type=apartment unit	geometry_average_ceiling_height=8	geometry_unit_aspect_ratio=0.5556																						
-Geometry Building Type RECS	Multi-Family with 5+ Units	ResStockArguments	geometry_unit_type=apartment unit	geometry_average_ceiling_height=8	geometry_unit_aspect_ratio=0.5556																						
-Geometry Building Type RECS	Mobile Home	ResStockArguments	geometry_unit_type=single-family detached	geometry_average_ceiling_height=8	geometry_unit_aspect_ratio=1.8																						
+Geometry Building Type RECS	Single-Family Detached	ResStockArguments	geometry_unit_type=single-family detached	geometry_unit_aspect_ratio=1.8																						
+Geometry Building Type RECS	Single-Family Attached	ResStockArguments	geometry_unit_type=single-family attached	geometry_unit_aspect_ratio=0.5556																						
+Geometry Building Type RECS	Multi-Family with 2 - 4 Units	ResStockArguments	geometry_unit_type=apartment unit	geometry_unit_aspect_ratio=0.5556																						
+Geometry Building Type RECS	Multi-Family with 5+ Units	ResStockArguments	geometry_unit_type=apartment unit	geometry_unit_aspect_ratio=0.5556																						
+Geometry Building Type RECS	Mobile Home	ResStockArguments	geometry_unit_type=single-family detached	geometry_unit_aspect_ratio=1.8																						
+Geometry Ceiling Height	8 ft	ResStockArguments	geometry_average_ceiling_height=8					
+Geometry Ceiling Height	9 ft	ResStockArguments	geometry_average_ceiling_height=9					
+Geometry Ceiling Height	10 ft	ResStockArguments	geometry_average_ceiling_height=10					
 Geometry Building Type ACS	Single-Family Detached																										
 Geometry Building Type ACS	Single-Family Attached																										
 Geometry Building Type ACS	2 Unit																										


### PR DESCRIPTION
## Pull Request Description

- ER-450 and ER-451
- Add an explicit "Geometry Ceiling Height" parameter, instead of having geometry_average_ceiling_height inside Geometry Building Type RECS

## Checklist

Not all may apply:

- [ ] Tests (and test files) have been updated
- [ ] Documentation has been updated
- [ ] Changelog has been updated
- [ ] `openstudio tasks.rb update_measures` has been run
- [ ] No unexpected regression test changes on CI (checked comparison artifacts)
