### PR TITLE
ER-523 - Bump number of ApplyUpgrade options to 31 (31 needed)

### DIFF
--- a/measures/ApplyUpgrade/resources/constants.rb
+++ b/measures/ApplyUpgrade/resources/constants.rb
@@ -2,7 +2,7 @@
 
 class Constants
   def self.NumApplyUpgradeOptions
-    return 30
+    return 31
   end
 
   def self.NumApplyUpgradesCostsPerOption


### PR DESCRIPTION
## Pull Request Description

Because I'm increasing the logic options in the seed project, I had to bump the number of options.

## Checklist

Not all may apply:

- [ ] Tests (and test files) have been updated
- [ ] Documentation has been updated
- [ ] Changelog has been updated
- [ ] `openstudio tasks.rb update_measures` has been run
- [ ] No unexpected regression test changes on CI (checked comparison artifacts)
